### PR TITLE
fix: don't raise `InconsistentPropertyNamesException` if annotation of ExtensionData differs

### DIFF
--- a/JsonPatchDocumentExtensionDataAdapter/JsonPatchDocumentExtensionDataAdapter/InconsistentPropertyNamesException.cs
+++ b/JsonPatchDocumentExtensionDataAdapter/JsonPatchDocumentExtensionDataAdapter/InconsistentPropertyNamesException.cs
@@ -30,7 +30,7 @@ public class InconsistentPropertyNamesException : Exception
         string? systemTextPropertyName = null
     )
         : base(
-            $"The system.text.property name {systemTextPropertyName ?? "(unset)"} and the newtonsoft json property{newtonsoftJsonPropertyName ?? "(unset)"} name don't match for property {propertyName}. Because the logic of this package relies on System.Text.Json but ASP.NET Core relies on Newtonsoft internally, both have to match"
+            $"The system.text.property name {systemTextPropertyName ?? "(unset)"} and the newtonsoft json property {newtonsoftJsonPropertyName ?? "(unset)"} name don't match for property {propertyName}. Because the logic of this package relies on System.Text.Json but ASP.NET Core relies on Newtonsoft internally, both have to match"
         )
     {
         PropertyName = propertyName;

--- a/JsonPatchDocumentExtensionDataAdapter/JsonPatchDocumentExtensionDataAdapter/JsonPatchDocumentExtensionDataAdapter.cs
+++ b/JsonPatchDocumentExtensionDataAdapter/JsonPatchDocumentExtensionDataAdapter/JsonPatchDocumentExtensionDataAdapter.cs
@@ -77,45 +77,55 @@ public class JsonPatchDocumentExtensionDataAdapter<TModel>
                     propertyInfo.GetCustomAttribute<JsonPropertyNameAttribute>();
                 var newtonsoftJsonPropertyAttribute =
                     propertyInfo.GetCustomAttribute<Newtonsoft.Json.JsonPropertyAttribute>();
-                if (
-                    newtonsoftJsonPropertyAttribute is not null
-                    && systemTextJsonPropertyNameAttribute is null
-                )
-                {
-                    throw new InconsistentPropertyNamesException(
-                        propertyInfo.Name,
-                        newtonsoftJsonPropertyAttribute.PropertyName,
-                        null
-                    );
-                }
-                if (
-                    systemTextJsonPropertyNameAttribute is not null
-                    && newtonsoftJsonPropertyAttribute is null
-                )
-                {
-                    throw new InconsistentPropertyNamesException(
-                        propertyInfo.Name,
-                        null,
-                        systemTextJsonPropertyNameAttribute.Name
-                    );
-                }
-                if (
-                    newtonsoftJsonPropertyAttribute is not null
-                    && systemTextJsonPropertyNameAttribute is not null
-                )
+
+                var extensionDataAttribute =
+                    propertyInfo.GetCustomAttribute<JsonExtensionDataAttribute>();
+                bool propertyJsonNameIsRelevant = extensionDataAttribute is null;
+                if (propertyJsonNameIsRelevant)
                 {
                     if (
-                        newtonsoftJsonPropertyAttribute.PropertyName
-                        != systemTextJsonPropertyNameAttribute.Name
+                        newtonsoftJsonPropertyAttribute is not null
+                        && systemTextJsonPropertyNameAttribute is null
                     )
                     {
                         throw new InconsistentPropertyNamesException(
                             propertyInfo.Name,
                             newtonsoftJsonPropertyAttribute.PropertyName,
+                            null
+                        );
+                    }
+
+                    if (
+                        systemTextJsonPropertyNameAttribute is not null
+                        && newtonsoftJsonPropertyAttribute is null
+                    )
+                    {
+                        throw new InconsistentPropertyNamesException(
+                            propertyInfo.Name,
+                            null,
                             systemTextJsonPropertyNameAttribute.Name
                         );
                     }
+
+                    if (
+                        newtonsoftJsonPropertyAttribute is not null
+                        && systemTextJsonPropertyNameAttribute is not null
+                    )
+                    {
+                        if (
+                            newtonsoftJsonPropertyAttribute.PropertyName
+                            != systemTextJsonPropertyNameAttribute.Name
+                        )
+                        {
+                            throw new InconsistentPropertyNamesException(
+                                propertyInfo.Name,
+                                newtonsoftJsonPropertyAttribute.PropertyName,
+                                systemTextJsonPropertyNameAttribute.Name
+                            );
+                        }
+                    }
                 }
+
                 var jsonPropertyName =
                     newtonsoftJsonPropertyAttribute?.PropertyName
                     ?? systemTextJsonPropertyNameAttribute?.Name

--- a/JsonPatchDocumentExtensionDataAdapter/UnitTest/InconsistencyTests.cs
+++ b/JsonPatchDocumentExtensionDataAdapter/UnitTest/InconsistencyTests.cs
@@ -21,4 +21,14 @@ public class InconsistencyTests
             .Should()
             .ThrowExactly<InconsistentPropertyNamesException>();
     }
+
+    [TestMethod]
+    public void Inconsistent_Serialization_Settings_Raise_NoError_On_ExtensionData_Name()
+    {
+        var instantiatingWithInvalidAttributes = () =>
+            new JsonPatchDocumentExtensionDataAdapter<MyClassWithInconsistentJsonNameAttributes>(
+                x => x.MyExtensionData
+            );
+        instantiatingWithInvalidAttributes.Should().NotThrow<InconsistentPropertyNamesException>();
+    }
 }

--- a/JsonPatchDocumentExtensionDataAdapter/UnitTest/Models.cs
+++ b/JsonPatchDocumentExtensionDataAdapter/UnitTest/Models.cs
@@ -66,7 +66,7 @@ internal class MyClassWithInconsistentJsonNameAttributes
     public int Foo { get; set; }
     public string? Bar { get; set; }
 
-    [System.Text.Json.Serialization.JsonPropertyName("thePropertyWithTheExtensionData")]
+    [System.Text.Json.Serialization.JsonPropertyName("thePropertyWithTheExtensionData")] // this name is inconsistent but not relevant as it's the extension data themselves
     // no newtonsoft attribute here
     [System.Text.Json.Serialization.JsonExtensionData]
     public IDictionary<string, object>? MyExtensionData { get; set; }


### PR DESCRIPTION
because that's the only name that is not relevant
